### PR TITLE
Fix decompress problem

### DIFF
--- a/zip/zlib.nim
+++ b/zip/zlib.nim
@@ -252,6 +252,7 @@ proc uncompress*(sourceBuf: cstring, sourceLen: int): string =
     while true:
       # Allocate more output space if none left.
       if space == have:
+        decompressed.setLen(space)
         # Double space, handle overflow.
         space = space shl 1
         if space < have:


### PR DESCRIPTION
There was a problem when decompressed data were more than twice bigger
than compressed one.
On memory expanding by setlen something went wrong. As a result we got
lots of '\0' in the result data beginning.
Probably it'd happened because setlen does not copy data to reallocated
memory.
I fixed it by replacing setlen to simple string concatenation.
