### PR TITLE
Undefine HAVE_STRUCT_TM_TM_ZONE for windows.

### DIFF
--- a/zip/private/libzip_all.c
+++ b/zip/private/libzip_all.c
@@ -306,7 +306,11 @@ ZIP_EXTERN int zip_unchange_archive(struct zip *);
 #define HAVE_STRING_H 1
 
 /* Define to 1 if `tm_zone' is member of `struct tm'. */
+#ifdef WIN32
+#undef HAVE_STRUCT_TM_TM_ZONE
+#else
 #define HAVE_STRUCT_TM_TM_ZONE 1
+#endif
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1


### PR DESCRIPTION
It seems like tm_gmtoff is not available on windows.
