### PR TITLE
Update libzip.so version mask

### DIFF
--- a/zip/libzip.nim
+++ b/zip/libzip.nim
@@ -51,7 +51,7 @@ when defined(unix) and not defined(useLibzipSrc):
   when defined(macosx):
     {.pragma: mydll, dynlib: "libzip(|2|4).dylib".}
   else:
-    {.pragma: mydll, dynlib: "libzip(|2).so(|.2|.1|.0)".}
+    {.pragma: mydll, dynlib: "libzip(|2).so(|.4|.2|.1|.0)".}
 else:
   when defined(unix):
     {.passl: "-lz".}


### PR DESCRIPTION
For example, Ubuntu 16.04 uses libzip.so.4