### PR TITLE
Better compatibility with compilers called externally.

### DIFF
--- a/zip/libzip.nim
+++ b/zip/libzip.nim
@@ -55,7 +55,7 @@ when defined(unix) and not defined(useLibzipSrc):
 else:
   when defined(unix):
     {.passl: "-lz".}
-  {.compile: "zip/private/libzip_all.c".}
+  {.emit: staticRead("private/libzip_all.c").}
   {.pragma: mydll.}
 
 type


### PR DESCRIPTION
Emit c code instead of using `compile` pragma. This is useful in cases (such as mine in android case) when external build toolchain is run upon nimcache dir.