### PR TITLE
removed return in uncompress

### DIFF
--- a/zip/zlib.nim
+++ b/zip/zlib.nim
@@ -213,7 +213,7 @@ proc compress*(sourceBuf: cstring; sourceLen: int; level=Z_DEFAULT_COMPRESSION; 
   ## Compression level can be set with ``level`` argument. Currently
   ## ``Z_DEFAULT_COMPRESSION`` is 6.
   ##
-  ## Returns nil on failure.
+  ## Returns "" on failure.
   assert(not sourceBuf.isNil)
   assert(sourceLen >= 0)
 
@@ -262,13 +262,10 @@ proc compress*(input: string; level=Z_DEFAULT_COMPRESSION; stream=GZIP_STREAM): 
   ##  - ``GZIP_STREAM`` - add a basic gzip header and footer.
   ##  - ``RAW_DEFLATE`` - no header is generated.
   ##
-  ## Passing a nil string will crash this proc in release mode and assert in
-  ## debug mode.
-  ##
   ## Compression level can be set with ``level`` argument. Currently
   ## ``Z_DEFAULT_COMPRESSION`` is 6.
   ##
-  ## Returns nil on failure.
+  ## Returns "" on failure.
   result = compress(input, input.len, level, stream)
 
 proc uncompress*(sourceBuf: cstring, sourceLen: Natural; stream=DETECT_STREAM): string =
@@ -284,7 +281,7 @@ proc uncompress*(sourceBuf: cstring, sourceLen: Natural; stream=DETECT_STREAM): 
   ## Passing a nil cstring will crash this proc in release mode and assert in
   ## debug mode.
   ##
-  ## Returns nil on problems. Failure is a very loose concept, it could be you
+  ## Returns "" on problems. Failure is a very loose concept, it could be you
   ## passing a non deflated string, or it could mean not having enough memory
   ## for the inflated version.
   ##
@@ -383,10 +380,7 @@ proc uncompress*(sourceBuf: string; stream=DETECT_STREAM): string =
   ##   - ``GZIP_STREAM`` - decompress a gzip stream.
   ##   - ``RAW_DEFLATE`` - decompress a raw deflate stream.
   ##
-  ## Passing a nil string will crash this proc in release mode and assert in
-  ## debug mode.
-  ##
-  ## Returns nil on failure.
+  ## Returns "" on failure.
   result = uncompress(sourceBuf, sourceBuf.len, stream)
 
 
@@ -399,14 +393,11 @@ proc deflate*(buffer: var string; level=Z_DEFAULT_COMPRESSION; stream=GZIP_STREA
   ##   - ``GZIP_STREAM`` - add a basic gzip header and footer.
   ##   - ``RAW_DEFLATE`` - no header is generated.
   ##
-  ## Passing a nil string will crash this proc in release mode and assert in
-  ## debug mode.
-  ##
   ## Compression level can be set with ``level`` argument. Currently
   ## ``Z_DEFAULT_COMPRESSION`` is 6.
   ##
   ## Returns true if `buffer` was successfully deflated otherwise the buffer is untouched.
-  assert(buffer.len != 0)
+
   var temp = compress(addr(buffer[0]), buffer.len, level, stream)
   if temp.len != 0:
     swap(buffer, temp)
@@ -423,12 +414,11 @@ proc inflate*(buffer: var string; stream=DETECT_STREAM): bool {.discardable.} =
   ##   - ``GZIP_STREAM`` - decompress a gzip stream.
   ##   - ``RAW_DEFLATE`` - decompress a raw deflate stream.
   ##
-  ## Passing a nil string will crash this proc in release mode and assert in
-  ## debug mode. It is ok to pass a buffer which doesn't contain deflated data,
+  ## It is ok to pass a buffer which doesn't contain deflated data,
   ## in this case the proc won't modify the buffer.
   ##
   ## Returns true if `buffer` was successfully inflated.
-  assert(buffer.len != 0)
+ 
   var temp = uncompress(addr(buffer[0]), buffer.len, stream)
   if temp.len != 0:
     swap(buffer, temp)

--- a/zip/zlib.nim
+++ b/zip/zlib.nim
@@ -305,8 +305,6 @@ proc uncompress*(sourceBuf: cstring, sourceLen: Natural; stream=DETECT_STREAM): 
   of DETECT_STREAM: MAX_WBITS + 32
 
   var status = inflateInit2(z, wbits.int32)
-  if status != Z_OK:
-    return
 
   case status
   of Z_OK: discard
@@ -408,9 +406,9 @@ proc deflate*(buffer: var string; level=Z_DEFAULT_COMPRESSION; stream=GZIP_STREA
   ## ``Z_DEFAULT_COMPRESSION`` is 6.
   ##
   ## Returns true if `buffer` was successfully deflated otherwise the buffer is untouched.
-  assert(not buffer.isNil)
+  assert(buffer.len != 0)
   var temp = compress(addr(buffer[0]), buffer.len, level, stream)
-  if not temp.isNil:
+  if temp.len != 0:
     swap(buffer, temp)
     result = true
 
@@ -430,8 +428,8 @@ proc inflate*(buffer: var string; stream=DETECT_STREAM): bool {.discardable.} =
   ## in this case the proc won't modify the buffer.
   ##
   ## Returns true if `buffer` was successfully inflated.
-  assert(not buffer.isNil)
+  assert(buffer.len != 0)
   var temp = uncompress(addr(buffer[0]), buffer.len, stream)
-  if not temp.isNil:
+  if temp.len != 0:
     swap(buffer, temp)
     result = true


### PR DESCRIPTION
`uncompress` would return in the case `inflateInit2` didn't return `Z_OK` instead of raising an exception. i think that this was a mistake but i'm not sure.